### PR TITLE
Minor changes to align to original API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,8 +8,8 @@
 			"sources": [ "pfio.cc" ],
 			'link_settings': {
 				'libraries': [
-					'-lmcp23s17',
-					'-lpifacedigital'
+					'-lpifacedigital',
+					'-lmcp23s17'
 				]
 			}
 		}

--- a/pfio.cc
+++ b/pfio.cc
@@ -26,7 +26,7 @@ void PfioDeinit(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void PfioDigitalRead(const v8::FunctionCallbackInfo<v8::Value>& args) {
 	Isolate* isolate = args.GetIsolate();
 	uint8_t pin = Integer::New(isolate, args[0]->IntegerValue())->Value();
-	uint8_t val = pifacedigital_digital_read(pin);
+	uint8_t val = pifacedigital_digital_read(pin) ^ 1; // invert value to match original API
 	args.GetReturnValue().Set(val);
 }
 
@@ -43,7 +43,7 @@ void PfioReadInput(const v8::FunctionCallbackInfo<v8::Value>& args) {
 	if (args.Length() >= 1) {
 		hw_addr = Integer::New(isolate, args[0]->IntegerValue())->Value();
 	}
-	uint8_t val = pifacedigital_read_reg(INPUT, hw_addr);
+	uint8_t val = pifacedigital_read_reg(INPUT, hw_addr) ^ 0xFF; // invert value to match original API
 	args.GetReturnValue().Set(val);
 }
 

--- a/pfio.cc
+++ b/pfio.cc
@@ -10,7 +10,7 @@ void PfioInit(const v8::FunctionCallbackInfo<v8::Value>& args) {
 	if (args.Length() >= 1) {
 		hw_addr = Integer::New(isolate, args[0]->IntegerValue())->Value();
 	}
-	uint8_t pifacedigital_fd = pifacedigital_open(hw_addr);
+	int pifacedigital_fd = pifacedigital_open(hw_addr);
 	args.GetReturnValue().Set(pifacedigital_fd);
 }
 


### PR DESCRIPTION
Tried using your version for my project but realised there were a few things outstanding. This is what I did:

- Fixed order of the libraries in build file (found solution from the question you raised).
- Changed return type of init() in case a -1 is returned in error condition.
- Applied the inversion to the read functions to align with original API. - the inversion is no longer done in the newer libpifacedigital, not sure why.

It's now working in my garage-control node project but I'm not using all the functions so not fully tested. 